### PR TITLE
Check if imported files has been changed

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,14 +1,17 @@
 /*!
  * Less - middleware (adapted from the stylus middleware)
- * 
+ *
  * Original Copyright(c) 2010 LearnBoost <dev@learnboost.com>
  * MIT Licensed
  */
 
-var less = require('less');
-var fs = require('fs');
-var url = require('url');
-var join = require('path').join;
+var less = require('less'),
+    fs = require('fs'),
+    url = require('url'),
+    basename = require('path').basename,
+    dirname = require('path').dirname,
+    mkdirp = require('mkdirp'),
+    join = require('path').join;
 
 // Import map
 var imports = {};
@@ -65,6 +68,26 @@ module.exports = less.middleware = function(options){
     if(options.debug) console.error('  \033[90m%s :\033[0m \033[36m%s\033[0m', key, val);
   };
 
+  //check imports for changes
+  var checkImports = function(path, fn) {
+    var nodes = imports[path];
+    if (!nodes) return fn();
+    if (!nodes.length) return fn();
+
+    var pending = nodes.length
+      , changed = [];
+    console.log(nodes);
+    nodes.forEach(function(imported){
+      fs.stat(imported.path, function(err, stat) {
+        // error or newer mtime
+        if (err || !imported.mtime || stat.mtime > imported.mtime) {
+          changed.push(imported.path);
+        }
+        --pending || fn(changed);
+      });
+    });
+  }
+
   // Once option
   options.once = options.once || false;
 
@@ -84,7 +107,7 @@ module.exports = less.middleware = function(options){
   // Default compile callback
   options.render = options.render || function(str, lessPath, cssPath, callback) {
     var parser = new less.Parser({
-      paths: [options.src],
+      paths: [dirname(lessPath)],
       filename: lessPath,
       optimization: options.optimization
     });
@@ -93,6 +116,17 @@ module.exports = less.middleware = function(options){
       var css = tree.toCSS({
         compress: (options.compress == 'auto' ? regex.compress.test(cssPath) : options.compress)
       });
+
+      imports[lessPath] = tree.rules
+        .filter(function(rule) {
+          return rule.path;
+        })
+        .map(function(rule) {
+          return {
+            mtime : Date.now(),
+            path : join(dirname(lessPath), rule.path)
+          };
+        });
 
       callback(err, css);
     });
@@ -132,13 +166,14 @@ module.exports = less.middleware = function(options){
 
           options.render(str, lessPath, cssPath, function(err, css){
             if (err) { return next(err); }
-            
+
             log('render', lessPath);
 
             // Store that it has been compiled
-            imports[lessPath] = lessPath;
-
-            fs.writeFile(cssPath, css, 'utf8', next);
+            mkdirp(dirname(cssPath), 0777, function(err){
+              if (err) return error(err);
+              fs.writeFile(cssPath, css, 'utf8', next);
+            });
           });
         });
       };
@@ -170,12 +205,18 @@ module.exports = less.middleware = function(options){
             }
           } else if (lessStats.mtime > cssStats.mtime) {
             log('modified', cssPath);
-            
+
             // Source has changed, compile it
             compile();
           } else {
-            // File not changed, handle normally
-            next();
+            checkImports(lessPath, function(changed){
+              if (options.debug && changed.length) {
+                changed.forEach(function(path) {
+                  log('modified import %s', path);
+                });
+              }
+              changed.length ? compile() : next();
+            });
           }
         });
       });


### PR DESCRIPTION
Over the weekend I did some work on converting stylus middleware to work with less, only after that I noticed this repository. 

So I thought I might as well share what I did.

This make sure that less gets recompiled if "@import 'foobar'" file gets changed.
