### PR TITLE
Fixed crash on client refresh

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -213,7 +213,7 @@ module.exports = less.middleware = function(options){
           } else {
             // Check if any of the less imports were changed
             checkImports(lessPath, function(changed){
-              if(changed.length) {
+              if(typeof changed != "undefined" && changed.length) {
                 log('modified import', changed);
 
                 compile();


### PR DESCRIPTION
When refreshing client, and no files were changed, less-middleware would crash due to accessing .length of undefined.

Running:
- express v3.0.0alpha1
- node v0.6.15
- less-middleware v0.1.2
