### PR TITLE
Request method checking fails on lowercase

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -141,7 +141,7 @@ module.exports = less.middleware = function(options){
 
   // Middleware
   return function(req, res, next) {
-    if ('GET' != req.method && 'HEAD' != req.method) { return next(); }
+    if ('GET' != req.method.toUpperCase() && 'HEAD' != req.method.toUpperCase()) { return next(); }
 
     var pathname = url.parse(req.url).pathname;
 


### PR DESCRIPTION
Hello,
I noted that LESS Middleware only accepted request methods that were uppercase (**GET** and **HEAD**). I've fixed this behavior to accept also **get**, **head** or any other variant.

I found this issue because [AppJS](http://github.com/appjs/appjs) passes the request as lowercase, and so my application was failing.
