### PR TITLE
Optionally strip a prefix from the path

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -25,6 +25,7 @@ var imports = {};
  *    `src`             Source directory used to find .less files
  *    `dest`            Destination directory used to output .css files
  *                      when undefined defaults to `src`.
+ *    `prefix`          Path which should be stripped from `src
  *    `compress`        Whether the output .css files should be compressed
  *    `yuicompress`     Same as `compress`, but uses YUI Compressor
  *    `optimization`    The desired value of the less optimization option (0, 1, or 2. 0 is default)
@@ -161,6 +162,9 @@ module.exports = less.middleware = function(options){
     if ('GET' != req.method.toUpperCase() && 'HEAD' != req.method.toUpperCase()) { return next(); }
 
     var pathname = url.parse(req.url).pathname;
+    if (options.prefix && 0 === pathname.indexOf(options.prefix)) {
+      pathname = pathname.substring(options.prefix.length);
+    }
 
     // Only handle the matching files
     if (regex.handle.test(pathname)) {


### PR DESCRIPTION
Love how easy it is to get up and running with this. Thanks :) Perhaps there's a better solution for my use case, but here's my attempt at solving it. For example, I'd like to have all files under a folder `src/less` compile to a matching tree of css files under `public/css`. 

Currently setting `src` and `dest to these paths doesn't work since requesting`css/styles.css`will look in`src/less/css/styles.css`(assuming all files under`public` are served relative to the root.)

I solved this by allowing an optional prefix to be stripped from the beginning of the path name. In the case above, setting `prefix` to `/css/` in the options does the trick. I'm not sure I'm happy with this solution, so I'm open to other ideas :)
