### PR TITLE
Always report LESS parse errors

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -65,7 +65,7 @@ module.exports = less.middleware = function(options){
 
   // Only log if in debug mode
   var log = function(key, val, type) {
-    if(options.debug) {
+    if(options.debug || type === 'error') {
       switch(type) {
         case 'log':
         case 'info':
@@ -136,6 +136,11 @@ module.exports = less.middleware = function(options){
     });
 
     parser.parse(str, function(err, tree) {
+      if (err) {
+        callback(err, css);
+        return;
+      }
+
       var css = tree.toCSS({
         compress: (options.compress == 'auto' ? regex.compress.test(cssPath) : options.compress),
         yuicompress: options.yuicompress


### PR DESCRIPTION
If you have an error in your LESS file (Edit - and debug: false), the console will print out:

```
TypeError: Cannot call method 'toCSS' of undefined
    at module.exports.less.middleware.options.render (/Users/jon/Dropbox/Sites/butter/node_modules/less-middleware/lib/middleware.js:139:22)
    at Object.less.Parser.parser.parse (/Users/jon/Dropbox/Sites/butter/node_modules/less/lib/less/parser.js:332:24)
    at Object.module.exports.less.middleware.options.render (/Users/jon/Dropbox/Sites/butter/node_modules/less-middleware/lib/middleware.js:138:12)
    at module.exports.less.middleware.compile (/Users/jon/Dropbox/Sites/butter/node_modules/less-middleware/lib/middleware.js:197:21)
    at fs.readFile (fs.js:176:14)
    at Object.oncomplete (fs.js:297:15)
```

This is because the default LESS parser callback does not check for `err` before trying to convert the tree to CSS.

I also changed the log function to always log error messages. It looks like that used to be the default from issue #8 and issue #12, but it was removed.
