### PR TITLE
Properly handle parse errors and pass them via error parameter in callback

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -136,29 +136,33 @@ module.exports = less.middleware = function(options){
     });
 
     parser.parse(str, function(err, tree) {
-      if (err) {
-        callback(err, css);
-        return;
-      }
+      try {
+        if (err) {
+          callback(err, css);
+          return;
+        }
 
-      var css = tree.toCSS({
-        compress: (options.compress == 'auto' ? regex.compress.test(cssPath) : options.compress),
-        yuicompress: options.yuicompress
-      });
-
-      // Store the less import paths
-      imports[lessPath] = tree.rules
-        .filter(function(rule) {
-          return rule.path;
-        })
-        .map(function(rule) {
-          return {
-            mtime : Date.now(),
-            path : path.join(path.dirname(lessPath), rule.path)
-          };
+        var css = tree.toCSS({
+          compress: (options.compress == 'auto' ? regex.compress.test(cssPath) : options.compress),
+          yuicompress: options.yuicompress
         });
 
-      callback(err, css);
+        // Store the less import paths
+        imports[lessPath] = tree.rules
+          .filter(function(rule) {
+            return rule.path;
+          })
+          .map(function(rule) {
+            return {
+              mtime : Date.now(),
+              path : path.join(path.dirname(lessPath), rule.path)
+            };
+          });
+
+        callback(err, css);
+      } catch(parseError) {
+        callback(parseError, null);
+      }
     });
   };
 


### PR DESCRIPTION
I had a problem which I described in http://stackoverflow.com/questions/12881556/catch-and-trace-middleware-exceptions-less-middleware-in-express-3-0 - this pull request solves it.
