### PR TITLE
added dumpLineNumbers support

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -29,6 +29,7 @@ var imports = {};
  *    `compress`        Whether the output .css files should be compressed
  *    `yuicompress`     Same as `compress`, but uses YUI Compressor
  *    `optimization`    The desired value of the less optimization option (0, 1, or 2. 0 is default)
+ *    `dumpLineNumbers` Add line tracking to the compiled css. ('comments' or 'mediaquery')
  *
  * Examples:
  *
@@ -120,6 +121,9 @@ module.exports = less.middleware = function(options){
   // Optimization option
   options.optimization = options.optimization || 0;
 
+  // Line Number Tracking
+  options.dumpLineNumbers = options.dumpLineNumbers || 0;
+
   // Source dir required
   var src = options.src;
   if (!src) { throw new Error('less.middleware() requires "src" directory'); }
@@ -144,7 +148,8 @@ module.exports = less.middleware = function(options){
     var parser = new less.Parser({
       paths: paths,
       filename: lessPath,
-      optimization: options.optimization
+      optimization: options.optimization,
+      dumpLineNumbers: options.dumpLineNumbers
     });
 
     parser.parse(str, function(err, tree) {

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,12 @@
             <td>Desired level of LESS optimization. Optionally <code>0</code>, <code>1</code>, or <code>2</code></td>
             <td><code>0</code></td>
         </tr>
+        <tr>
+            <th><code>dumpLineNumbers</th>
+            <td>Add line tracking to the compiled css. Optionally <code>0</code>, <code>'comments'</code>, or <code>'mediaquery'</code></td>
+            <td><code>0</code></td>
+        </tr>
+
     </tbody>
 </table>
 


### PR DESCRIPTION
Added an options flag 'dumpLineNumbers', and passed through directly to the parser with a default of 0.

(Adds comments or media query lines for source code line tracking)

Thanks for your work on this middleware, made my life much easier.
