### PR TITLE
Update to the readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,8 +140,8 @@ Since less middleware relies on static content to be served by express.static, u
 
         var tmpDir = os.tmpDir();
         app.use(lessMiddleware({
-            dest: __dirname + '/public/stylesheets',
-            src: tmpDir,
+            src: __dirname + '/public/stylesheets',
+            dest: tmpDir,
             compress: true
         }));
 


### PR DESCRIPTION
I added a note about using a temp directory (os.tmpDir() as an example) with less.js-middleware.
