### PR TITLE
Fix error when LESS parser failed to parse the tree

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -153,11 +153,8 @@ module.exports = less.middleware = function(options){
     });
 
     parser.parse(str, function(err, tree) {
+      if(err) return callback(err);
       try {
-        if (err) {
-          callback(err, css);
-          return;
-        }
 
         var css = tree.toCSS({
           compress: (options.compress == 'auto' ? regex.compress.test(cssPath) : options.compress),


### PR DESCRIPTION
`css` variable used before its declaration in `parser.parse` callback function
