### PR TITLE
Use strict mode

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*!
  * Less - middleware (adapted from the stylus middleware)
  *
@@ -234,7 +236,7 @@ module.exports = less.middleware = function(options){
 
               log('render', lessPath);
 
-              mkdirp(path.dirname(cssPath), 0777, function(err){
+              mkdirp(path.dirname(cssPath), 511 /* 0777 */, function(err){
                 if (err) return error(err);
 
                 fs.writeFile(cssPath, css, 'utf8', next);


### PR DESCRIPTION
Enables use of `node --use_strict` by packages that rely on this.

`mkdirp` is also guilty of this (one of this package's dependencies). I've [submitted a PR to them](https://github.com/substack/node-mkdirp/pull/36), but the maintainer has been unresponsive (see [the issue mentioning it being broken in strict mode](https://github.com/substack/node-mkdirp/issues/32)), so it may not get accepted soon, if ever. In the meantime, you could link directly to my branch in your `package.json`, if you would like. Example:

```
"mkdirp": "git://github.com/bfrohs/node-mkdirp.git#strictMode"
```
