### PR TITLE
Add source map support

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -130,6 +130,9 @@ module.exports = less.middleware = function(options){
   // Relative paths?
   options.relativeUrls = options.relativeUrls || false;
 
+  // Source map
+  options.sourceMap = options.sourceMap || false;
+
   // Source dir required
   var src = options.src;
   if (!src) { throw new Error('less.middleware() requires "src" directory'); }
@@ -170,7 +173,8 @@ module.exports = less.middleware = function(options){
         try {
           var css = tree.toCSS({
             compress: (options.compress == 'auto' ? regex.compress.test(cssPath) : options.compress),
-            yuicompress: options.yuicompress
+            yuicompress: options.yuicompress,
+            sourceMap: options.sourceMap
           });
 
           // Store the less import paths

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "lib/middleware.js",
   "dependencies": {
-    "less": "~1.4",
+    "less": "~1.5",
     "mkdirp": "~0.3"
   },
   "devDependencies": {},

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,11 @@
             <td>Adjust urls to be relative to directory of files imported with @import. If false, urls will remain unchanged.</td>
             <td><code>false</code></td>
         </tr>
+        <tr>
+            <th><code>sourceMap</th>
+            <td>Enable sourcemap support. You can compile your less and then use developer tools to see where in your less file a particular piece of css comes from.</td>
+            <td><code>false</code></td>
+        </tr>
 
     </tbody>
 </table>


### PR DESCRIPTION
This PR uses the built-in sourceMap support in less.js 1.5.0.

(PR #47 implements its own stuff)
