### PR TITLE
fix octal usage in strict mode

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -80,7 +80,7 @@ module.exports = less.middleware = function(options){
           type = 'log';
       }
 
-      console[type]('  \033[90m%s :\033[0m \033[36m%s\033[0m', key, val);
+      console[type]("  \u001b[90m%s :\u001b[0m \u001b[36m%s\u001b[0m", key, val);
     }
   };
 


### PR DESCRIPTION
The debug console logging function uses octal escape sequences to change colours. Octals are forbidden in strict mode and thus an uncaughtException is raised.
