### PR TITLE
proxy any options to less

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -160,16 +160,13 @@ module.exports = less.middleware = function(options){
   // Default compile callback
   options.render = options.render || function(str, lessPath, cssPath, callback) {
 
-    var paths = [ path.dirname(lessPath) ];
-    options.paths.forEach(function(p){ paths.push(p); });
+    var opt = extend({}, options);
+    opt.paths.unshift(path.dirname(lessPath));
+    opt.filename = lessPath;
+    opt.compress = (opt.compress == 'auto' ? regex.compress.test(cssPath) : opt.compress);
+    opt.sourceMapBasepath = (opt.sourceMapBasepath ? opt.sourceMapBasepath : path.dirname(lessPath));
 
-    var parser = new less.Parser({
-      paths: paths,
-      filename: lessPath,
-      optimization: options.optimization,
-      dumpLineNumbers: options.dumpLineNumbers,
-      relativeUrls: options.relativeUrls
-    });
+    var parser = new less.Parser(opt);
 
     parser.parse(str, function(err, tree) {
         if(err) {
@@ -177,14 +174,10 @@ module.exports = less.middleware = function(options){
         }
 
         try {
-          var css = tree.toCSS({
-            compress: (options.compress == 'auto' ? regex.compress.test(cssPath) : options.compress),
-            yuicompress: options.yuicompress,
-            sourceMap: options.sourceMap
-          });
+          var css = tree.toCSS(opt);
 
           // Store the less import paths
-          imports[lessPath] = determine_imports(tree, lessPath, options.paths);
+          imports[lessPath] = determine_imports(tree, lessPath, opt.paths);
 
           callback(err, css);
         } catch(parseError) {


### PR DESCRIPTION
I was trying to use the middleware and set sourcemap-related options, but they were all ignored.

Looking at https://github.com/less/less.js/blob/master/bin/lessc there are no conflicting options between the options for the parser and for the toCSS function, so I'm not differentiating in my PR.
