### PR TITLE
correct semver usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   },
   "main": "lib/middleware.js",
   "dependencies": {
-    "less": "~1.5",
-    "mkdirp": "~0.3",
-    "node.extend": "~1.0"
+    "less": "~1.5.1",
+    "mkdirp": "~0.3.5",
+    "node.extend": "~1.0.8"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
Current `package.json` tells NPM that it's ok to install all minor and patch upgrades for the dependencies - e.g. ~1.5 tests true for 1.x.x - but minor upgrades can introduce breaking changes.

This PR restricts upgrades on the patch level only.
