### PR TITLE
bump LESS dependency version to 1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "lib/middleware.js",
   "dependencies": {
-    "less": "~1.5.1",
+    "less": "~1.6.1",
     "mkdirp": "~0.3.5",
     "node.extend": "~1.0.8"
   },


### PR DESCRIPTION
A new major version of LESS was released earlier this month. The latest version is now 1.6.1. 

Here's the changelog: https://github.com/less/less.js/blob/v1.6.1/CHANGELOG.md
