### PR TITLE
Switch `less` to be a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "url": "git://github.com/emberfeather/less.js-middleware.git"
   },
   "main": "lib/middleware.js",
+  "peerDependencies": {
+    "less": "~1.6.1"
+  },
   "dependencies": {
-    "less": "~1.6.1",
     "mkdirp": "~0.3.5",
     "node.extend": "~1.0.8"
   },


### PR DESCRIPTION
I was trying to use this middleware and define some of my own `treeFunctions` in the options to add some functionality to the pre-processor for asset fingerprinting. I found that you actually need to use classes from the less codebase (like `less.tree.Anonymous` and others) when writing a `treeFunctions` function in order to return a valid value.

Now, of course, I can just add `less` to my own project's `package.json` and then require it. However, because the Less that this Less middleware uses is a dependency, it might end up being a different version than the one I have in the top-level project. It seems dangerous to be creating a class instance of something like `less.tree.Anonymous` from one version of Less and returning it to code from a different version of Less. The `treeFunctions` effectively end up being version-mismatched, potentially.

I think the right solution might be to make `less` a [peer dependency](http://blog.nodejs.org/2013/02/07/peer-dependencies/) of this project instead of a normal dependency. That way, which I include `less-middleware`, a version of `less` is also npm-installed at the top level, and there won't be any version mismatches when I require it myself, since this code will be requiring the same version of Less from the top level of my own project.

This branch makes the change to switch the `less` dependency to peer dependency. If desired, `less` could also be added as a dev dependency for local development of this library, but it didn't seem like the library really has a local development setup, so I didn't add that.
