### PR TITLE
Use url to parse req.url

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -13,6 +13,7 @@ var fs = require('fs');
 var less = require('less');
 var mkdirp = require('mkdirp');
 var path = require('path');
+var url = require('url');
 var utilities = require('./utilities');
 
 // Import mapping.
@@ -126,7 +127,7 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
   return function(req, res, next) {
     if ('GET' != req.method.toUpperCase() && 'HEAD' != req.method.toUpperCase()) { return next(); }
 
-    var pathname = req.path;
+    var pathname = url.parse(req.url).pathname;
 
     // Only handle the matching files in this middleware.
     if (utilities.isValidPath(pathname)) {


### PR DESCRIPTION
`req.pathname` is not supported in connect. Other than this, the rewritten middleware still supports connect so it would be great to have this change.
