### PR TITLE
Filename wasn't a string

### DIFF
--- a/lib/determine-imports.js
+++ b/lib/determine-imports.js
@@ -45,7 +45,7 @@ var process_import_rule = module.exports.process_import_rule = function process_
 // and then again in the directory of the top level less file being imported.
 var locate = module.exports.locate = function (filename, current_dir, root_dir, additional_import_paths) {
   var i, import_path, from_import_path;
-  filename = filename.value;
+  filename = filename.value.value;
   if (!filename.match(/\.(css|less)$/))
       filename += '.less';
   var from_current_path = path.join(current_dir, filename);


### PR DESCRIPTION
And would give a "no known method 'match'" error when attempting to import a less file, this seems to fix that.
