### PR TITLE
Multiple Directory Support

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -209,18 +209,31 @@ module.exports = less.middleware = function(options){
       }
 
       var cssPath = path.join(dest, pathname);
-      var lessPath = path.join(src, (
-        regex.compress.test(pathname)
-        ? pathname.replace(regex.compress, '.less')
-        : pathname.replace('.css', '.less'
-      )));
+      
+      if (typeof(src) == 'string') src = [ src ];
+      
+      var lessPath = null;
+      src.forEach(function( s ) {
+        if (lessPath) return;
 
-      if (root) {
-        cssPath = path.join(root, dest, pathname.replace(dest, ''));
-        lessPath = path.join(root, src, pathname
-            .replace(dest, '')
-            .replace('.css', '.less'));
-      }      
+        var testPath = path.join(s, (
+          regex.compress.test(pathname)
+          ? pathname.replace(regex.compress, '.less')
+          : pathname.replace('.css', '.less'
+        )));
+        
+        if (root) {
+          cssPath = path.join(root, dest, pathname.replace(dest, ''));
+          testPath = path.join(root, s, pathname
+              .replace(dest, '')
+              .replace('.css', '.less'));
+        }
+        
+        var exists = fs.existsSync( testPath );
+          
+        if (exists) lessPath = testPath;
+        
+      });
 
       log('source', lessPath);
       log('dest', cssPath);
@@ -233,6 +246,8 @@ module.exports = less.middleware = function(options){
       // Compile to cssPath
       var compile = function() {
         log('read', lessPath);
+        
+        if (!lessPath) return error({ code: 'ENOENT' });
 
         fs.readFile(lessPath, 'utf8', function(err, str){
           if (err) { return error(err); }


### PR DESCRIPTION
This adds support for passing an array of paths as `src` that will be sequentially tested for a source file, and ultimately return 404 if no matching file is found.  The first match will be the rendered match.

This is implemented as a branch from `0.1.15`, as this starting point seemed a bit more straightforward – I'm opening the pull request to `master` as I'd like to have support for this in the updated version, and am willing to change the implementation to do so.
