### PR TITLE
add globalVars option

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -110,6 +110,7 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
     debug: false,
     dest: source,
     force: false,
+    globalVars : null,
     once: false,
     parser: extend(true, {
       dumpLineNumbers: 0,
@@ -153,6 +154,16 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
     var parser = new less.Parser(extend({}, options.parser, {
       filename: lessPath
     }));
+
+    if (options.globalVars){
+      var varString = '';
+      for (var key in options.globalVars){
+        if (options.globalVars.hasOwnProperty(key)){
+          varString += '@' + key + ':' + options.globalVars[key] + ';';
+        }
+      }
+      str = varString + str;
+    }
 
     parser.parse(str, function(err, tree) {
       if(err) {

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,11 @@ The following options can be used to control the behavior of the middleware:
             <td><code>false</code></td>
         </tr>
         <tr>
+            <th><code>globalVars</code></th>
+            <td>An object containing key value pairs that will be injected as global LESS <code>@variables</code> at runtime</td>
+            <td><code>null</code></td>
+        </tr>
+        <tr>
             <th><code>once</code></th>
             <td>Only recompile once after each server restart. Useful for reducing disk i/o on production.</td>
             <td><code>false</code></td>

--- a/test/fixtures/vars-exp.css
+++ b/test/fixtures/vars-exp.css
@@ -1,0 +1,1 @@
+.baz{width:120px;color:#f0f0f0}

--- a/test/fixtures/vars.less
+++ b/test/fixtures/vars.less
@@ -1,0 +1,4 @@
+.baz {
+    width: @foo * 10px;
+    color: @bar;
+}

--- a/test/test-middleware.js
+++ b/test/test-middleware.js
@@ -29,6 +29,7 @@ var setupExpress = function(src, options, staticDest) {
 }
 
 describe('middleware', function(){
+
   describe('simple', function(){
     var app = setupExpress(__dirname + '/fixtures', {
       dest: tmpDest
@@ -178,6 +179,25 @@ describe('middleware', function(){
             .expect(200)
             .expect(expected, done);
         });
+      });
+    });
+
+    describe('globalVars', function() {
+      var app = setupExpress(__dirname + '/fixtures', {
+        dest: tmpDest,
+        force : true,
+        globalVars: {
+          foo : 12,
+          bar : '#f0f0f0'
+        }
+      });
+
+      it('should inject runtime/enviroment variables', function(done){
+        var expected = fs.readFileSync(__dirname + '/fixtures/vars-exp.css', 'utf8');
+        request(app)
+          .get('/vars.css')
+          .expect(200)
+          .expect(expected, done);
       });
     });
 


### PR DESCRIPTION
This PR adds a `globalVars` option to the middleware, enabling the user to set LESS `@variables` at runtime (based on the application's environment variables for example).

While the solution (prepending a string before parsing) might seem hacky, this seems to be the only way to do this programatically. See the Grunt LESS task doing this the exact same way as a reference: https://github.com/gruntjs/grunt-contrib-less/blob/master/tasks/less.js#L129

This would also close #109 