### PR TITLE
passing req to storeCss

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -126,7 +126,7 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
       less: function(src, req) { return src; },
       path: function(pathname, req) { return pathname; }
     },
-    storeCss: function(pathname, css, next) {
+    storeCss: function(pathname, css, next, req) {
       mkdirp(path.dirname(pathname), 511 /* 0777 */, function(err){
         if (err) return next(err);
 
@@ -252,7 +252,7 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
               css = options.postprocess.css(css, req);
 
               // Allow postprocessing for custom storage.
-              options.storeCss(cssPath, css, next);
+              options.storeCss(cssPath, css, next, req);
             });
           } catch (err) {
             utilities.lessError(err);


### PR DESCRIPTION
I had the need to pass the `req` object to storeCss in order to create different file names based on request specific information. I can only imagine this would be useful to others. 

`req` is passed as the 4th, optional parameter so not to break any existing code. 