### PR TITLE
allow preprocessing parser paths

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -124,7 +124,7 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
     },
     preprocess: {
       less: function(src, req) { return src; },
-      path: function(pathname, req) { return pathname; }
+      path: function(pathname, req) { return pathname; },
       parserPaths: function(paths, req) { return paths; }
     },
     storeCss: function(pathname, css, next) {
@@ -151,6 +151,7 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
 
   // Parse and compile the CSS from the source string.
   var render = function(str, lessPath, cssPath, callback) {
+    console.log('options.parser', options.parser.paths);
     var parser = new less.Parser(extend({}, options.parser, {
       filename: lessPath
     }));
@@ -216,8 +217,8 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
       var cssPath = path.join(options.dest, pathname);
 
       // Allow for preprocessing the parser paths
-      var parserPaths = options.parser.options;
-      options.parser.options = options.preprocess.parserPaths(parserPaths, req);
+      var parserPaths = options.parser.paths;
+      options.parser.paths = options.preprocess.parserPaths(parserPaths, req);
 
       if (options.pathRoot) {
         pathname = pathname.replace(options.dest, '');

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -151,7 +151,6 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
 
   // Parse and compile the CSS from the source string.
   var render = function(str, lessPath, cssPath, callback) {
-    console.log('options.parser', options.parser.paths);
     var parser = new less.Parser(extend({}, options.parser, {
       filename: lessPath
     }));

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -125,6 +125,7 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
     preprocess: {
       less: function(src, req) { return src; },
       path: function(pathname, req) { return pathname; }
+      parserPaths: function(paths, req) { return paths; }
     },
     storeCss: function(pathname, css, next) {
       mkdirp(path.dirname(pathname), 511 /* 0777 */, function(err){
@@ -213,6 +214,10 @@ module.exports = less.middleware = function(source, options, parserOptions, comp
       }
       var lessPath = path.join(source, utilities.maybeCompressedSource(pathname));
       var cssPath = path.join(options.dest, pathname);
+
+      // Allow for preprocessing the parser paths
+      var parserPaths = options.parser.options;
+      options.parser.options = options.preprocess.parserPaths(parserPaths, req);
 
       if (options.pathRoot) {
         pathname = pathname.replace(options.dest, '');

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,11 @@ The following options can be used to control the behavior of the middleware:
             <td><code>function(pathname, req){...}</code></td>
         </tr>
         <tr>
+            <th><code>preprocess.parserPaths</code></th>
+            <td>Function that modifies the parser paths before being parsed and compiled.</td>
+            <td><code>function(paths, req){...}</code></td>
+        </tr>
+        <tr>
             <th><code>storeCss</code></th>
             <td>Function that is in charge of storing the css in the filesystem.</td>
             <td><code>function(pathname, css, next){...}</code></td>

--- a/test/external/2.43.3/externalvariables.less
+++ b/test/external/2.43.3/externalvariables.less
@@ -1,0 +1,1 @@
+@externalColor: #f03;

--- a/test/external/2.43.3/ui/ui.less
+++ b/test/external/2.43.3/ui/ui.less
@@ -1,0 +1,1 @@
+@paddingBox: 20px;

--- a/test/fixtures/preprocessParserPaths-exp.css
+++ b/test/fixtures/preprocessParserPaths-exp.css
@@ -1,0 +1,1 @@
+.widget{color:#f03;padding:20px}

--- a/test/fixtures/preprocessParserPaths.less
+++ b/test/fixtures/preprocessParserPaths.less
@@ -1,0 +1,6 @@
+@import "externalvariables.less";
+@import "ui.less";
+.widget {
+  color: @externalColor;
+  padding: @paddingBox;
+}

--- a/test/test-middleware.js
+++ b/test/test-middleware.js
@@ -170,8 +170,7 @@ describe('middleware', function(){
           dest: tmpDest,
           preprocess: {
             path: function(pathname, req) {
-                var version = req.url.match(/(?:\/application\/)([0-9\.0-9\.0-9]*)/),
-                    returnPath = pathname.replace(/(\/application\/[0-9\.0-9\.0-9].*\/)/, '/');
+                var returnPath = pathname.replace(/(\/application\/[0-9\.0-9\.0-9].*\/)/, '/');
                 return returnPath;
             },
             parserPaths: function(paths, req) {

--- a/test/test-middleware.js
+++ b/test/test-middleware.js
@@ -165,6 +165,36 @@ describe('middleware', function(){
         });
       });
 
+      describe('parserPaths', function(){
+        var app = setupExpress(__dirname + '/fixtures', {
+          dest: tmpDest,
+          preprocess: {
+            path: function(pathname, req) {
+                var version = req.url.match(/(?:\/application\/)([0-9\.0-9\.0-9]*)/),
+                    returnPath = pathname.replace(/(\/application\/[0-9\.0-9\.0-9].*\/)/, '/');
+                return returnPath;
+            },
+            parserPaths: function(paths, req) {
+              var version = req.url.match(/(?:\/application\/)([0-9\.0-9\.0-9]*)/),
+                  reqPath = path.join(__dirname,'external', version[1] , '/'),
+                  paths = [
+                    reqPath,
+                    path.join(reqPath, 'ui')
+                  ];
+              return paths;
+            }
+          }
+        });
+
+        it('should respond with newly mapped paths', function(done){
+          var expected = fs.readFileSync(__dirname + '/fixtures/preprocessParserPaths-exp.css', 'utf8');
+          request(app)
+            .get('/application/2.43.3/preprocessParserPaths.css')
+            .expect(200)
+            .expect(expected, done);
+        });
+      });
+
       describe('pathRoot', function(){
         var app = setupExpress('/fixtures', {
           dest: '/artifacts',


### PR DESCRIPTION
For dynamic uses of parsing less of requests where you would have let say different versions of an application available, this PR makes it possible to modify the parser-paths.

Example:
```
preprocess : {
    parserPaths: function(paths, req) {
        var version = req.url.match(/(?:\/application\/)([0-9\.0-9\.0-9]*)/);
        var reqPath = path.join(basePath, version[1]);
        return [
            path.join(reqPath, 'ui', 'less'),
            path.join(reqPath, 'ui', 'less', 'lib')
        ];
    }
}
```

This comes from a real usage example, though I know it's not a common case.
I don't see it as a big overhead but up to you if you want to include the possibility for this usage.