### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "engines": {
     "node": ">= 0.7.1"
   },
+  "license": "MIT",
   "scripts": {
     "test": "./node_modules/.bin/mocha"
   }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license